### PR TITLE
Verbesserte Fehlerbehandlung und Validierung

### DIFF
--- a/proxmox-id-changer.sh
+++ b/proxmox-id-changer.sh
@@ -40,7 +40,12 @@ case $OLD_VMID in
     ;;
 esac
 
-echo
+
+# Überprüfen, ob die VM läuft
+if qm status "$OLD_VMID" 2>/dev/null | grep -q running || pct status "$OLD_VMID" 2>/dev/null | grep -q running; then
+    echo -e "${RED}Fehler: Die VM mit der ID $OLD_VMID läuft noch. Bitte stoppen Sie sie zuerst.${NC}"
+    exit 1
+fi
 
 # Neue VMID eingeben
 echo -e "${YELLOW}Bitte geben Sie die neue VMID ein:${NC}"
@@ -56,42 +61,70 @@ case $NEW_VMID in
     ;;
 esac
 
+# Überprüfen, ob die neue VMID bereits existiert
+if [ -f "/etc/pve/$VM_TYPE/$NEW_VMID.conf" ]; then
+    echo -e "${RED}Fehler: Eine VM mit der ID $NEW_VMID existiert bereits.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Neue VMID: $NEW_VMID${NC}"
 echo
 
 # Debug-Ausgabe für Logical Volumes
 echo -e "${YELLOW}Überprüfe logische Volumes für VMID $OLD_VMID...${NC}"
-lvs_output=$(lvs --noheadings -o lv_name,vg_name)
+lvs_output=$(lvs --noheadings -o lv_name,vg_name 2>/dev/null || echo "Keine LVM gefunden")
 echo -e "${GREEN}Logische Volumes Ausgabe:${NC}"
 echo "$lvs_output"
 
 # Suche nach Volume Group
-VG_NAME=$(echo "$lvs_output" | grep -E "\s$OLD_VMID\b" | awk '{print $2}' | uniq)
+VG_NAME=$(echo "$lvs_output" | grep -E "vm-$OLD_VMID-disk" | awk '{print $2}' | uniq)
 
 if [ -z "$VG_NAME" ]; then
   echo -e "${YELLOW}Keine LVM-Volumes gefunden für VMID $OLD_VMID. Überprüfe ZFS-Volumes...${NC}"
 else
   echo -e "${GREEN}Volume Group: $VG_NAME${NC}"
-  for volume in $(lvs -a | grep "$VG_NAME" | awk '{print $1}' | grep "$OLD_VMID"); do
+  for volume in $(lvs --noheadings -o lv_name,vg_name | grep "$VG_NAME" | grep "vm-$OLD_VMID-disk" | awk '{print $1}'); do
     newVolume="${volume//"${OLD_VMID}"/"${NEW_VMID}"}"
     echo -e "${YELLOW}Benenne Volume $volume zu $newVolume um${NC}"
-    lvrename "$VG_NAME" "$volume" "$newVolume"
+    if ! lvrename "$VG_NAME" "$volume" "$newVolume"; then
+      echo -e "${RED}Fehler beim Umbenennen von $volume zu $newVolume${NC}"
+      exit 1
+    fi
   done
 fi
 
 echo -e "${YELLOW}Überprüfe ZFS-Volumes für VMID $OLD_VMID...${NC}"
-zfs_output=$(zfs list -t all)
+zfs_output=$(zfs list -t all 2>/dev/null || echo "Keine ZFS gefunden")
 echo -e "${GREEN}ZFS-Ausgabe:${NC}"
 echo "$zfs_output"
 
 # ZFS-Volumes umbenennen
-for volume in $(echo "$zfs_output" | awk '{print $1}' | grep -E "vm-${OLD_VMID}-disk|subvol-${OLD_VMID}-disk"); do
-  newVolume="${volume//"${OLD_VMID}"/"${NEW_VMID}"}"
-  echo -e "${YELLOW}Benenne ZFS-Volume $volume zu $newVolume um${NC}"
-  zfs rename "$volume" "$newVolume"
-done
+zfs_volumes=$(echo "$zfs_output" | grep -E "vm-${OLD_VMID}-disk|subvol-${OLD_VMID}-disk" | awk '{print $1}')
+if [ -n "$zfs_volumes" ]; then
+  for volume in $zfs_volumes; do
+    newVolume="${volume//"${OLD_VMID}"/"${NEW_VMID}"}"
+    echo -e "${YELLOW}Benenne ZFS-Volume $volume zu $newVolume um${NC}"
+    if ! zfs rename "$volume" "$newVolume"; then
+      echo -e "${RED}Fehler beim Umbenennen von $volume zu $newVolume${NC}"
+      exit 1
+    fi
+  done
+else
+  echo -e "${YELLOW}Keine ZFS-Volumes für VMID $OLD_VMID gefunden.${NC}"
+fi
 
 echo -e "${YELLOW}Aktualisiere Konfigurationsdateien...${NC}"
-sed -i "s/$OLD_VMID/$NEW_VMID/g" /etc/pve/"$VM_TYPE"/"$OLD_VMID".conf
-mv /etc/pve/"$VM_TYPE"/"$OLD_VMID".conf /etc/pve/"$VM_TYPE"/"$NEW_VMID".conf
+if [ ! -f "/etc/pve/$VM_TYPE/$OLD_VMID.conf" ]; then
+  echo -e "${RED}Konfigurationsdatei /etc/pve/$VM_TYPE/$OLD_VMID.conf nicht gefunden.${NC}"
+  exit 1
+fi
 
-echo -e "${GREEN}Fertig!${NC}"
+# Konfigurationsdatei aktualisieren
+sed -i "s/$OLD_VMID/$NEW_VMID/g" "/etc/pve/$VM_TYPE/$OLD_VMID.conf"
+if ! mv "/etc/pve/$VM_TYPE/$OLD_VMID.conf" "/etc/pve/$VM_TYPE/$NEW_VMID.conf"; then
+  echo -e "${RED}Fehler beim Umbenennen der Konfigurationsdatei.${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}Die VMID wurde erfolgreich von $OLD_VMID zu $NEW_VMID geändert.${NC}"
+echo -e "${YELLOW}Sie müssen gegebenenfalls die Proxmox-Weboberfläche neu laden, um die Änderungen zu sehen.${NC}"


### PR DESCRIPTION
Dieses Pull Request verbessert die Stabilität und Sicherheit des Proxmox-ID-Changer Scripts durch folgende Änderungen:

### Verbesserungen:
- Überprüfung, ob die VM bereits läuft, bevor Änderungen vorgenommen werden
- Überprüfung, ob die neue VMID bereits existiert, um Konflikte zu vermeiden
- Verbesserte Fehlerbehandlung für LVM- und ZFS-Operationen
- Genauere Suche nach VM-spezifischen Volumes
- Robustere Fehlerbehandlung mit aussagekräftigen Fehlermeldungen

### Grund für den PR?
Das Original-Skript funktionierte bei mir unter Proxmox 8.4.5 mit einem normalen LVM-Setup nicht korrekt. Nach der VM-ID-Änderung erschien der Fehler "TASK ERROR: no such logical volume" beim Booten der VM, jedoch hat das Script keinen Fehler ausgegeben. Diese Anpassungen beheben dieses Problem und machen das Skript robuster für verschiedene Setups.


Getestet auf Proxmox 8.4.5 mit LVM-Storage.